### PR TITLE
Fix for ncurses patch under archlinux

### DIFF
--- a/package/ncurses/0002-gcc-5.x-MKlib_gen.patch
+++ b/package/ncurses/0002-gcc-5.x-MKlib_gen.patch
@@ -22,7 +22,7 @@ Index: b/ncurses/base/MKlib_gen.sh
 +# Work around "unexpected" output of GCC 5.1.0's cpp w.r.t. #line directives
 +# by simply suppressing them:
 +case `$1 -dumpversion 2>/dev/null` in
-+	5.[01].*)  # assume a "broken" one
++	5.[012].*)  # assume a "broken" one
 +		preprocessor="$1 -P -DNCURSES_INTERNALS -I../include"
 +		;;
 +	*)


### PR DESCRIPTION
Archlinux uses GCC 5.2, which is newer than the GCC versions that this
ncurses patch worked for.