### PR TITLE
Update dtc-overlay URL

### DIFF
--- a/package/dtc-overlay/Config.in.host
+++ b/package/dtc-overlay/Config.in.host
@@ -6,4 +6,4 @@ config BR2_PACKAGE_HOST_DTC_OVERLAY
 
 	  This version is patched to support device tree overlays.
 
-	  https://github.com/atenart/dtc
+	  https://github.com/NextThingCo/dtc

--- a/package/dtc-overlay/dtc-overlay.mk
+++ b/package/dtc-overlay/dtc-overlay.mk
@@ -4,8 +4,8 @@
 #
 ################################################################################
 
-DTC_OVERLAY_VERSION = 61bbb7e7719959dc70917ae855398d278afa99c7
-DTC_OVERLAY_SITE = $(call github,atenart,dtc,$(DTC_OVERLAY_VERSION))
+DTC_OVERLAY_VERSION = 93f8c3a7d6bb37cc414a7116264361cb737f2966
+DTC_OVERLAY_SITE = $(call github,NextThingCo,dtc,$(DTC_OVERLAY_VERSION))
 DTC_OVERLAY_LICENSE = GPLv2+/BSD-2c
 DTC_OVERLAY_LICENSE_FILES = README.license GPL
 DTC_OVERLAY_DEPENDENCIES = host-bison host-flex

--- a/package/dtc-overlay/dtc-overlay.mk
+++ b/package/dtc-overlay/dtc-overlay.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-DTC_OVERLAY_VERSION = 93f8c3a7d6bb37cc414a7116264361cb737f2966
+DTC_OVERLAY_VERSION = 61bbb7e7719959dc70917ae855398d278afa99c7
 DTC_OVERLAY_SITE = $(call github,NextThingCo,dtc,$(DTC_OVERLAY_VERSION))
 DTC_OVERLAY_LICENSE = GPLv2+/BSD-2c
 DTC_OVERLAY_LICENSE_FILES = README.license GPL


### PR DESCRIPTION
It seems the repo https://github.com/atenart/dtc no longer exists, and this causes buildroot to fail as described in https://github.com/NextThingCo/CHIP-buildroot/issues/37, since host-dtc-overlay cannot be resolved.

The host-dtc-overlay URL has been updated to point to the latest commit of the "debian" branch of the NTC repo instead: https://github.com/NextThingCo/dtc/tree/debian

This allows compilation to proceed, and seems to fix #37.

Although this allows compilation to proceed perhaps this is the wrong repo to be pulling in; please correct me if I am wrong!  There is also an NTC forum post about this: https://bbs.nextthing.co/t/issue-with-buildroot-make-no-https-github-com-atenart-dtc/17466/5